### PR TITLE
fix: keep sticky state alive across unrelated keyups (#64)

### DIFF
--- a/static/js/sticky_attributes.js
+++ b/static/js/sticky_attributes.js
@@ -63,18 +63,24 @@ exports.aceKeyEvent = (hook, callstack, cb) => {
     evt.ctrlKey && (
       k === 66 || k === 73 || k === 85 || k === 53) && evt.type === 'keyup');
 
-  clientVars.sticky = {};
+  // Don't clobber an already-pending sticky on every unrelated keyup.
+  // aceEditEvent only consumes clientVars.sticky on the next
+  // `idleWorkTimer` tick, which typically fires *after* the key-up of
+  // the character that was just typed. The old code reset
+  // `clientVars.sticky = {}` at the top of every aceKeyEvent, so the
+  // keyup of the next typed character cleared the sticky state before
+  // the idleWorkTimer had a chance to apply bold — the keyboard
+  // shortcut silently did nothing (#64). The consumer in aceEditEvent
+  // already resets `setAttribute` back to false once it has applied.
+  if (!clientVars.sticky) clientVars.sticky = {};
 
   if (isAttributeKey) {
-    const attribute = attributes[k]; // which attribute is it?
     clientVars.sticky.setAttribute = true;
-    clientVars.sticky.attribute = attribute;
-  } else {
-    clientVars.sticky.setAttribute = false;
-    return cb(false);
+    clientVars.sticky.attribute = attributes[k];
+    return cb();
   }
 
-  return cb();
+  return cb(false);
 };
 
 const checkAttr = (context, documentAttributeManager) => {


### PR DESCRIPTION
Fixes #64. `aceEditEvent` consumes `clientVars.sticky` on an `idleWorkTimer` tick, which typically fires AFTER the keyup of the character just typed. The old code reset `clientVars.sticky = {}` at the top of every aceKeyEvent, so the keyup of that typed character clobbered the flag Ctrl+B/Ctrl+I/Ctrl+U/Ctrl+5 had just set. idleWorkTimer then saw no pending sticky and the shortcut silently did nothing.

Stop resetting on every keyup — leave the flag alone for non-attribute keys. aceEditEvent already sets `setAttribute = false` once it has applied, which is the correct time to clear it.